### PR TITLE
Make chart compatible to Fybrik 0.5.0

### DIFF
--- a/.github/workflows/push.sh
+++ b/.github/workflows/push.sh
@@ -1,0 +1,64 @@
+name: Push
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+
+env:
+  DOCKER_HOSTNAME: ghcr.io
+  DOCKER_NAMESPACE: fybrik
+  DOCKER_USERNAME: ${{ github.actor }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    # Versions are created as follows:
+    # - Tags starting with v will be released as what comes after `v`. (e.g. refs/tags/v1.0 -> 1.0).
+    # - Release branches will be released as the release number (e.g. refs/heads/releases/1.0 -> 1.0-rc).
+    # - Other branches (e.g. main) will be released with branch name as version for the docker images.
+    #   For the helm chart OCI reference tag 0.0.0-<branch-name> will be used.
+    - id: version
+      name: Infer version
+      run: |
+        version="${GITHUB_REF#refs/tags/v}"
+        echo "HELM_TAG=${version}" >> $GITHUB_ENV
+        if  [[ $version == refs/* ]] ;
+        then
+            branch="${GITHUB_REF#refs/heads/}"
+            version=$branch
+            echo "HELM_TAG=0.0.0-${version}" >> $GITHUB_ENV
+        elif [[ $version == releases/* ]] ;
+        then
+           releaseVersion="${GITHUB_REF#refs/heads/releases/}"
+           version="$releaseVersion-rc"
+           echo "HELM_TAG=$releaseVersion-rc" >> $GITHUB_ENV
+        fi
+        echo "DOCKER_TAGNAME=$version" >> $GITHUB_ENV
+    - name: Helm tool installer
+      uses: Azure/setup-helm@v1
+      with:
+        version: v3.6.3
+    - name: Build docker image 
+      run: make docker-build
+    - name: Docker push
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u "${{ env.DOCKER_USERNAME }}" --password-stdin "${{ env.DOCKER_HOSTNAME }}" 
+        make docker-push
+    - run: docker images
+    - name: Install yq
+      run: make ./hack/tools/bin/yq
+    - name: Update docker image tag in the chart value.yaml file
+      run: ./hack/tag_value.sh
+    - name: Helm chart push
+      run: |
+        export HELM_EXPERIMENTAL_OCI=1 
+        echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login -u "${{ github.actor }}" --password-stdin "${{ env.DOCKER_HOSTNAME }}" 
+        make helm-chart-push
+

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -1,0 +1,19 @@
+name: Release
+on: create
+jobs:
+  update-release-branch:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, 'refs/heads/releases/') }}
+    steps:
+    - id: version
+      name: Infer version
+      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/heads/releases/}
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Install yq
+      run: make ./hack/tools/bin/yq
+    - run: RELEASE=${{ steps.version.outputs.version }} ./hack/release.sh
+    - uses: EndBug/add-and-commit@v7
+      with:
+        default_author: github_actions

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ export DOCKER_NAMESPACE ?= fybrik
 export DOCKER_TAGNAME ?= 0.0.0
 
 DOCKER_IMG_NAME ?= hello-world-read-module
-DOCKER_CHART_IMG_NAME ?= hello-world-read-module-chart
+HELM_IMG_NAME ?= hello-world-read-module-chart
 DOCKER_FILE ?= Dockerfile
 DOCKER_CONTEXT ?= .
 HELM_TAG ?= ${DOCKER_TAGNAME}
 
 APP_IMG ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_IMG_NAME}:${DOCKER_TAGNAME}
-CHART_IMG ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_CHART_IMG_NAME}:${DOCKER_TAGNAME}
+CHART_IMG ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${HELM_IMG_NAME}:${HELM_TAG}
 
 .PHONY: docker-all
 docker-all: docker-build docker-push

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
-export DOCKER_USERNAME ?= Mohammad-nassar10
+include Makefile.env
+
+export DOCKER_USERNAME ?= fybrik
 export DOCKER_PASSWORD ?= 
 export DOCKER_HOSTNAME ?= ghcr.io
-export DOCKER_NAMESPACE ?= mohammad-nassar10
-export DOCKER_TAGNAME ?= v0.0.1
+export DOCKER_NAMESPACE ?= fybrik
+export DOCKER_TAGNAME ?= 0.0.0
 
 DOCKER_IMG_NAME ?= hello-world-read-module
 DOCKER_CHART_IMG_NAME ?= hello-world-read-module-chart
 DOCKER_FILE ?= Dockerfile
 DOCKER_CONTEXT ?= .
+HELM_TAG ?= ${DOCKER_TAGNAME}
 
 APP_IMG ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_IMG_NAME}:${DOCKER_TAGNAME}
 CHART_IMG ?= ${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}/${DOCKER_CHART_IMG_NAME}:${DOCKER_TAGNAME}
@@ -97,3 +100,6 @@ helm-actions:
 
 .PHONY: helm-all
 helm-all: helm-verify helm-chart-push helm-chart-pull helm-uninstall helm-chart-install
+
+include hack/make-rules/tools.mk
+

--- a/Makefile.env
+++ b/Makefile.env
@@ -1,0 +1,15 @@
+ARCH ?= amd64
+
+export ROOT_DIR ?= .
+export TOOLS_DIR := $(ROOT_DIR)/hack/tools
+export TOOLBIN := $(TOOLS_DIR)/bin
+export ABSTOOLBIN := $(shell pwd)/$(TOOLS_DIR)/bin
+export PATH:=$(ABSTOOLBIN):${PATH}
+
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+GOPATH=$(shell go env GOPATH)

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ make helm-chart-push
 
 To register HWRM (Hello Read World Module) as a Fybrik module apply `hello-world-read-module.yaml` to the fybrik-system namespace of your cluster.
 
-To install the latest release run:
-
+In order to install the latest release, run:
 ```bash
 kubectl apply -f https://github.com/fybrik/hello-world-read-module/releases/latest/download/hello-world-read-module.yaml -n fybrik-system
 ```
@@ -96,10 +95,9 @@ kubectl apply -f https://github.com/fybrik/hello-world-read-module/releases/late
 | 0.5.x            | 0.5.x   | `https://github.com/fybrik/hello-world-read-module/releases/download/v0.5.0/hello-world-read-module.yaml`
 | master           | main    | `https://raw.githubusercontent.com/fybrik/hello-world-read-module/main/hello-world-read-module.yaml`
 
-
 ## Deploy and test Fybrik module
 
-Follow this section to deploy and test the module on a single cluster.
+Here is an example how to deploy and test the module on a single cluster.
 
 ### Before you begin
 
@@ -107,11 +105,11 @@ Install Fybrik using the [Quick Start](https://fybrik.io/v0.5/get-started/quicks
 
 > ***Notice: Please follow `version compatbility matrix` section above for deploying the correct version of Fybrik and this module.***
 
-### Deploy Fybrik module
+### Deploy the `hello-world-read-module` module
 
-Deploy `FybrikModule` in `fybrik-system` namespace:
+Deploy this module in the `fybrik-system` namespace:
 ```bash
-kubectl create -f hello-world-read-module.yaml -n fybrik-system
+kubectl apply -f hello-world-read-module.yaml -n fybrik-system
 ```
 ### Test using Fybrik Notebook sample
 
@@ -156,7 +154,7 @@ rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": desc
 }
 ```
 
-  In this sample only the policy above is applied. Copy the policy to a file named sample-policy.rego and then run:
+  Copy the policies to a file named sample-policy.rego and then run:
 
 ```bash
 kubectl -n fybrik-system create configmap sample-policy --from-file=sample-policy.rego
@@ -182,9 +180,9 @@ kubectl get job -n fybrik-blueprints
 kubectl get pods -n fybrik-blueprints
 ```
 
-If you are using the `hello-world-read-module` image, you should see this in the `kubectl logs` of your completed Pod:
+If you are using the `hello-world-read-module` image, you should see this in the `kubectl logs -n fybrik-blueprints` of your completed Pod:
 ```
-$ kubectl logs my-notebook-default-hello-world-read-module-5f59d75c8f-v7z7p -n fybrik-blueprints
+$ kubectl logs my-notebook-default-hello-world-read-module-xx -n fybrik-blueprints
 
 INFO:root:
 Hello World Read Module!
@@ -225,3 +223,5 @@ Run the following command to delete the fybrik module:
 ```bash
 kubectl delete fybrikmodule hello-world-read-module -n fybrik-system
 ```
+
+Please execute the `Cleanup` section from [Fybrik notebook sample](https://fybrik.io/dev/samples/notebook/)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,18 @@
+# Release Process
+
+The process of creating a release is described in this document. Replace `X.Y.Z` with the version to be released.
+
+## 1. Create a `releases/X.Y.Z` branch 
+
+The `releases/X.Y.Z` branch should be created from a base branch. 
+
+For major and minor releases the base is `main` and for patch releases (fixes) the base is `releases/X.Y.(Z-1)`.
+A new patch release should be created before merging pull-requests as described in the next section.
+
+You can do that [directly from GitHub](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch).
+
+## 2. Create a [new release](https://github.com/fybrik/hello-world-read-module/releases/new) 
+
+Use `vX.Y.Z` tag and set `releases/X.Y.Z` as the target.
+
+Ensure that the release notes explicitly mention upgrade instructions and any breaking change.

--- a/fybrikapplication.yaml
+++ b/fybrikapplication.yaml
@@ -1,7 +1,7 @@
 apiVersion: app.fybrik.io/v1alpha1
 kind: FybrikApplication
 metadata:
-  name: hello-world-read-module-test
+  name: my-notebook 
 spec:
   selector:
    workloadSelector:
@@ -12,12 +12,12 @@ spec:
     purpose: Fraud Detection
     role: Data Owner
   data:
-    - dataSetID: "default/medals-winners"
+    - dataSetID: "fybrik-notebook-sample/medals-winners"
       requirements:
         interface:
           protocol: s3
           dataformat: csv
-    - dataSetID: "default/bank"
+    - dataSetID: "fybrik-notebook-sample/bank"
       requirements:
         interface:
           protocol: s3

--- a/hack/make-rules/tools.mk
+++ b/hack/make-rules/tools.mk
@@ -1,0 +1,4 @@
+INSTALL_TOOLS += $(TOOLBIN)/yq
+$(TOOLBIN)/yq:
+	cd $(TOOLS_DIR); ./install_yq.sh
+	$(call post-install-check)

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+: ${RELEASE:=main}
+: ${TOOLBIN:=./hack/tools/bin}
+
+${TOOLBIN}/yq eval --inplace ".version = \"$RELEASE\"" ./hello-world-read-module/Chart.yaml
+${TOOLBIN}/yq eval --inplace ".image.tag = \"$RELEASE\"" ./hello-world-read-module/values.yaml

--- a/hack/tag_value.sh
+++ b/hack/tag_value.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Copyright 2020 IBM Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+: ${RELEASE:=main}
+: ${TOOLBIN:=./hack/tools/bin}
+
+${TOOLBIN}/yq eval --inplace ".image.tag = \"$DOCKER_TAG\"" ./hello-world-read-module/values.yaml

--- a/hack/tag_value.sh
+++ b/hack/tag_value.sh
@@ -2,7 +2,7 @@
 # Copyright 2020 IBM Corp.
 # SPDX-License-Identifier: Apache-2.0
 
-: ${RELEASE:=main}
+: ${DOCKER_TAG:=main}
 : ${TOOLBIN:=./hack/tools/bin}
 
 ${TOOLBIN}/yq eval --inplace ".image.tag = \"$DOCKER_TAG\"" ./hello-world-read-module/values.yaml

--- a/hack/tools/common.sh
+++ b/hack/tools/common.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+arch=amd64
+os="unknown"
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  os="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  os="darwin"
+fi
+
+if [[ "$os" == "unknown" ]]; then
+  echo "OS '$OSTYPE' not supported. Aborting." >&2
+  exit 1
+fi
+
+# Turn colors in this script off by setting the NO_COLOR variable in your
+# environment to any value:
+#
+# $ NO_COLOR=1 test.sh
+NO_COLOR=${NO_COLOR:-""}
+if [ -z "$NO_COLOR" ]; then
+  header=$'\e[1;33m'
+  reset=$'\e[0m'
+else
+  header=''
+  reset=''
+fi
+
+function header_text {
+  echo "$header$*$reset"
+}
+
+export PATH=$(pwd)/bin:${PATH}
+

--- a/hack/tools/install_yq.sh
+++ b/hack/tools/install_yq.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+source ./common.sh
+
+header_text "Checking for bin/yq"
+[[ -f bin/yq ]] && exit 0
+
+header_text "Installing bin/yq"
+mkdir -p ./bin
+curl -L https://github.com/mikefarah/yq/releases/download/v4.6.0/yq_${os}_${arch} -o bin/yq
+chmod +x bin/yq
+

--- a/hello-world-module.py
+++ b/hello-world-module.py
@@ -51,7 +51,7 @@ class S(BaseHTTPRequestHandler):
             logging.info("Transformation action is {} for the columns {}\n".format(data['action'],data['transferred_columns']))
         else:
             self.wfile.write("invalid request\n".encode('utf-8'))
-            self.wfile.write("The avialable datasets:\n".encode('utf-8'))
+            self.wfile.write("The available datasets:\n".encode('utf-8'))
             for key in data_dict:
                 self.wfile.write("dataset name: {}\n".format(key).encode('utf-8'))
                 for k in data_dict[key]:
@@ -88,7 +88,7 @@ def run(config_path=None, server_class=HTTPServer, handler_class=S, addr="localh
                     transferred_columns = transformations['columns']
                     data_dict[name] = {'format':format, 'endpoint_url':endpoint_url, 'action':action, 'transferred_columns':transferred_columns}
                     
-    logging.info("The avialable datasets:\n")
+    logging.info("The available datasets:\n")
     for key in data_dict:
         logging.info("dataset name: {}\n".format(key))
         for k in data_dict[key]:

--- a/hello-world-read-module.yaml
+++ b/hello-world-read-module.yaml
@@ -10,15 +10,15 @@ metadata:
 spec:
   type: service
   chart:
-    name: ghcr.io/mohammad-nassar10/hello-world-read-module-chart:v0.0.1
+    name: ghcr.io/fybrik/hello-world-read-module-chart:0.0.0-main
     values:
-      image.tag: v0.0.1
+      image.tag: main
   capabilities:
     - capability: read
       scope: workload
       actions:
-        - id: redact-ID
-          level: 2  # column
+        - name: RedactAction
+        - name: RemoveAction
       api:
         endpoint:
           port: 80

--- a/hello-world-read-module/Chart.yaml
+++ b/hello-world-read-module/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
-name: hello-world-read-module
+name: hello-world-read-module-chart
 description: A Helm chart for installing a module for Fybrik in Kubernetes
-
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -11,13 +10,7 @@ description: A Helm chart for installing a module for Fybrik in Kubernetes
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.0.1"
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+version: "0.0.0"

--- a/hello-world-read-module/files/conf.yaml
+++ b/hello-world-read-module/files/conf.yaml
@@ -15,11 +15,11 @@ data:
     {{- $redactColumns := list -}}
     {{- $removeColumns := list -}}
     {{- range .transformations -}}
-      {{- if eq .id "redact-ID" -}}
-        {{- $redactColumns = append  $redactColumns .args.column_name -}}
+      {{- if eq .name "RedactAction" -}}
+        {{- $redactColumns = .RedactAction.columns -}}
       {{- end -}}
-      {{- if eq .id "removed-ID" -}}
-        {{- $removeColumns = append  $removeColumns .args.column_name -}}
+      {{- if eq .name "RemoveAction" -}}
+        {{- $removeColumns = .RemoveAction.columns -}}
       {{- end -}}
     {{- end -}}
     {{- if $redactColumns }}

--- a/hello-world-read-module/templates/_helpers.tpl
+++ b/hello-world-read-module/templates/_helpers.tpl
@@ -14,12 +14,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/hello-world-read-module/values.yaml
+++ b/hello-world-read-module/values.yaml
@@ -5,8 +5,8 @@
 replicaCount: 1
 
 image: 
-  repository: ghcr.io/mohammad-nassar10/hello-world-read-module
-  tag: v0.0.1
+  repository: ghcr.io/fybrik/hello-world-read-module
+  tag: main
   pullPolicy: Always
   pullSecret: null
 

--- a/sample_assets/secretBank.yaml
+++ b/sample_assets/secretBank.yaml
@@ -4,5 +4,5 @@ metadata:
   name: bank
 type: Opaque
 stringData:
-  access_key: "1234"
-  secret_key: "1234"
+  access_key: "${ACCESS_KEY}"
+  secret_key: "${SECRET_KEY}"

--- a/sample_assets/secretMedals.yaml
+++ b/sample_assets/secretMedals.yaml
@@ -4,5 +4,5 @@ metadata:
   name: medals-winners
 type: Opaque
 stringData:
-  access_key: "1234"
-  secret_key: "1234"
+  access_key: "${ACCESS_KEY}"
+  secret_key: "${SECRET_KEY}"


### PR DESCRIPTION
This PR makes the required changes for the chart to be compatible with Fybrik 0.5.0 release.

It contains:

- Updates to the tags used for publishing the chart and docker images to be compatible to Fybrik 0.5.0
- Fixes to README.md
- Fixes to the module charts to work with Fybrik 0.5.0

Closes #25 