### PR TITLE
Adjust the module to work with Fybrik 0.6.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The configuration for the chart is in the values file. -->
 ## Prerequisites
 
 - Kubernetes cluster 1.10+
-- Helm 3.0.0+
+- Helm 3.7.0+
 - Install Fybrik using the [Quick Start](https://fybrik.io/dev/get-started/quickstart/) guide.
 - Docker repository (such as ghcr.io).
 
@@ -27,7 +27,7 @@ Create a file to implement your usage of the read module. An example can be foun
 ### Modify values in Makefile
 
 In `Makefile`:
-- Create a registry for helm chart and docker image. Then change the fields `DOCKER_USERNAME`, `DOCKER_PASSWORD`, `DOCKER_HOSTNAME`, `DOCKER_NAMESPACE`, `DOCKER_TAGNAME`, `DOCKER_IMG_NAME`, and `DOCKER_CHART_IMG_NAME` to your own preferences. An example can be found in `Makefile`.
+- Create a registry for helm chart and docker image. Then change the fields `DOCKER_USERNAME`, `DOCKER_PASSWORD`, `DOCKER_HOSTNAME`, `DOCKER_NAMESPACE`, `DOCKER_TAGNAME`, `DOCKER_NAME`, and `HELM_TAG` to your own preferences. An example can be found in `Makefile`.
 - One possible option is to create public registries in github. Then create a Personal Access Token. In this case the field `DOCKER_USERNAME` will be your github username and `DOCKER_PASSWORD` is the Personal Access Token. Note that you need to change the visibility of the packages to public.
 
 ### Build Docker image for Python application
@@ -93,6 +93,7 @@ kubectl apply -f https://github.com/fybrik/hello-world-read-module/releases/late
 | Fybrik           | HWRM     | Command
 | ---              | ---     | ---
 | 0.5.x            | 0.5.x   | `https://github.com/fybrik/hello-world-read-module/releases/download/v0.5.0/hello-world-read-module.yaml`
+| 0.6.x            | 0.6.x   | `https://github.com/fybrik/hello-world-read-module/releases/download/v0.6.0/hello-world-read-module.yaml`
 | master           | main    | `https://raw.githubusercontent.com/fybrik/hello-world-read-module/main/hello-world-read-module.yaml`
 
 ## Deploy and test Fybrik module
@@ -101,7 +102,7 @@ Here is an example how to deploy and test the module on a single cluster.
 
 ### Before you begin
 
-Install Fybrik using the [Quick Start](https://fybrik.io/v0.5/get-started/quickstart/) guide. This sample assumes the use of the built-in catalog, Open Policy Agent (OPA) and flight module.
+Install Fybrik using the [Quick Start](https://fybrik.io/dev/get-started/quickstart/) guide. This sample assumes the use of the built-in catalog, Open Policy Agent (OPA) and flight module.
 
 > ***Notice: Please follow `version compatbility matrix` section above for deploying the correct version of Fybrik and this module.***
 
@@ -113,7 +114,9 @@ kubectl apply -f hello-world-read-module.yaml -n fybrik-system
 ```
 ### Test using Fybrik Notebook sample
 
-Execute the sections in [Fybrik Notebook sample](https://fybrik.io/v0.5/samples/notebook/) until `Register the dataset in a data catalog` section (excluded).
+> ***Notice: Please use the README.md file of the desired release as the resources in this example may change between releases.***
+
+Execute the sections in [Fybrik Notebook sample](https://fybrik.io/dev/samples/notebook/) until `Register the dataset in a data catalog` section (excluded).
 
 
 ## Register data asset in a data catalog
@@ -140,16 +143,16 @@ package dataapi.authz
 rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": description}] {
   description := "Redact columns tagged as PII in datasets tagged with finance = true"
   input.action.actionType == "read"
-  input.resource.tags.finance
-  column_names := [input.resource.columns[i].name | input.resource.columns[i].tags.PII]
+  input.resource.metadata.tags.finance
+  column_names := [input.resource.metadata.columns[i].name | input.resource.metadata.columns[i].tags.PII]
   count(column_names) > 0
 }
 
 rule[{"action": {"name":"RedactAction", "columns": column_names}, "policy": description}] {
   description := "Redact columns tagged as sensitive in datasets tagged with finance = true"
   input.action.actionType == "read"
-  input.resource.tags.finance
-  column_names := [input.resource.columns[i].name | input.resource.columns[i].tags.sensitive]
+  input.resource.metadata.tags.finance
+  column_names := [input.resource.metadata.columns[i].name | input.resource.metadata.columns[i].tags.sensitive]
   count(column_names) > 0
 }
 ```

--- a/fybrikapplication.yaml
+++ b/fybrikapplication.yaml
@@ -9,16 +9,13 @@ spec:
        app: notebook
      }
   appInfo:
-    purpose: Fraud Detection
-    role: Data Owner
+    intent: "Fraud Detection"
   data:
     - dataSetID: "fybrik-notebook-sample/medals-winners"
       requirements:
         interface:
-          protocol: s3
-          dataformat: csv
+          protocol: rest
     - dataSetID: "fybrik-notebook-sample/bank"
       requirements:
         interface:
-          protocol: s3
-          dataformat: csv
+          protocol: rest

--- a/hack/make-rules/helm.mk
+++ b/hack/make-rules/helm.mk
@@ -80,5 +80,5 @@ helm-actions: $(TOOLBIN)/helm
 	$(ABSTOOLBIN)/helm show values --version ${HELM_TAG}  ${CHART_REGISTRY_PATH} | yq -y -r .actions
 
 .PHONY: helm-all
-helm-all: helm-verify helm-chart-push helm-chart-pull helm-chart-install helm-uninstall
+helm-all: helm-verify helm-chart-push helm-chart-pull helm-uninstall helm-chart-install
 

--- a/hack/make-rules/helm.mk
+++ b/hack/make-rules/helm.mk
@@ -1,0 +1,84 @@
+# This script contains helm version 3.7 commands for pushing and pulling charts to OCI registry
+# as described in https://github.com/helm/community/blob/main/hips/hip-0006.md
+# To use it the following env vars should be defined:
+
+# CHART_NAME the chart name as is appear in Chart.yaml
+# HELM_RELEASE the helm release-name of the chart
+# HELM_TAG  the OCI reference tag (and also the chart version). Must be SemVer
+# CHART_LOCAL_PATH path to the chart directory
+# DOCKER_HOSTNAME the docker registry hostname
+# DOCKER_NAMESPACE docker registry namespace
+# DOCKER_USERNAME docker registry  username
+
+
+HELM_VALUES ?= \
+	--set hello=world1
+
+TEMP := /tmp
+CHART_LOCAL_PATH ?= hello-world-read-module
+CHART_NAME ?= hello-world-read-module-chart
+HELM_RELEASE ?= rel1-${DOCKER_NAME}
+HELM_TAG ?= 0.0.0
+
+CHART_REGISTRY_PATH := oci://${DOCKER_HOSTNAME}/${DOCKER_NAMESPACE}
+
+export HELM_EXPERIMENTAL_OCI=1
+export GODEBUG=x509ignoreCN=0
+
+.PHONY: helm-login
+helm-login: $(TOOLBIN)/helm
+ifneq (${DOCKER_PASSWORD},)
+	$(ABSTOOLBIN)/helm registry login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" ${DOCKER_HOSTNAME}
+endif
+
+.PHONY: helm-verify
+helm-verify: $(TOOLBIN)/helm
+	$(ABSTOOLBIN)/helm lint ${CHART_LOCAL_PATH}
+	$(ABSTOOLBIN)/helm install --dry-run ${HELM_RELEASE} ${CHART_LOCAL_PATH} ${HELM_VALUES}
+
+.PHONY: helm-uninstall
+helm-uninstall: $(TOOLBIN)/helm
+	$(ABSTOOLBIN)/helm uninstall ${HELM_RELEASE} || true
+
+.PHONY: helm-install
+helm-install: $(TOOLBIN)/helm
+	$(ABSTOOLBIN)/helm install ${HELM_RELEASE} ${CHART_LOCAL_PATH} ${HELM_VALUES}
+
+
+# example for helm chart push:
+# helm package fybrik-template -d /tmp/ --version 0.7.0
+# helm push /tmp/fybrik-template-0.7.0.tgz oci://localhost:5000/fybrik-system/
+.PHONY: helm-chart-push
+helm-chart-push: helm-login
+	$(ABSTOOLBIN)/helm package ${CHART_LOCAL_PATH} --version=${HELM_TAG} --destination=${TEMP}
+	$(ABSTOOLBIN)/helm push ${TEMP}/${CHART_NAME}-${HELM_TAG}.tgz ${CHART_REGISTRY_PATH}
+	rm -rf ${TEMP}/${CHART_NAME}-${HELM_TAG}.tgz
+
+.PHONY: helm-chart-pull
+helm-chart-pull: helm-login
+	$(ABSTOOLBIN)/helm pull ${CHART_REGISTRY_PATH}/${CHART_NAME} --version ${HELM_TAG}
+
+.PHONY: helm-list
+helm-list: $(TOOLBIN)/helm
+	$(ABSTOOLBIN)/helm list
+
+.PHONY: helm-chart-install
+helm-chart-install: $(TOOLBIN)/helm
+	$(ABSTOOLBIN)/helm install ${HELM_RELEASE} ${CHART_REGISTRY_PATH}/${CHART_NAME} --version ${HELM_TAG} ${HELM_VALUES}
+	$(ABSTOOLBIN)/helm list
+
+.PHONY: helm-template
+helm-template: $(TOOLBIN)/helm
+	$(ABSTOOLBIN)/helm template ${HELM_RELEASE} ${CHART_REGISTRY_PATH} --version ${HELM_TAG} ${HELM_VALUES}
+
+.PHONY: helm-debug
+helm-debug: $(TOOLBIN)/helm
+	$(ABSTOOLBIN)/helm template ${HELM_RELEASE} ${CHART_REGISTRY_PATH} ${HELM_VALUES} --version ${HELM_TAG} --debug
+
+.PHONY: helm-actions
+helm-actions: $(TOOLBIN)/helm
+	$(ABSTOOLBIN)/helm show values --version ${HELM_TAG}  ${CHART_REGISTRY_PATH} | yq -y -r .actions
+
+.PHONY: helm-all
+helm-all: helm-verify helm-chart-push helm-chart-pull helm-chart-install helm-uninstall
+

--- a/hack/make-rules/tools.mk
+++ b/hack/make-rules/tools.mk
@@ -2,3 +2,8 @@ INSTALL_TOOLS += $(TOOLBIN)/yq
 $(TOOLBIN)/yq:
 	cd $(TOOLS_DIR); ./install_yq.sh
 	$(call post-install-check)
+
+INSTALL_TOOLS += $(TOOLBIN)/helm
+$(TOOLBIN)/helm:
+	cd $(TOOLS_DIR); ./install_helm.sh
+	$(call post-install-check)

--- a/hack/tools/install_helm.sh
+++ b/hack/tools/install_helm.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+
+source ./common.sh
+
+DESIRED_VERSION=v3.7.0
+
+header_text "Checking for bin/helm $DESIRED_VERSION"
+[[ -f bin/helm &&  `bin/helm version --template='{{.Version}}'` == $DESIRED_VERSION ]] && exit 0
+
+header_text "Installing bin/helm $DESIRED_VERSION"
+# Helm is currently fixed to 3.6.3 until the deployment process is migrated to 3.7.0 (https://github.com/helm/helm/releases/tag/v3.7.0)
+# Some used experimental OCI features have been removed.
+mkdir -p ./bin
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+chmod 700 get_helm.sh
+HELM_INSTALL_DIR=bin ./get_helm.sh -v $DESIRED_VERSION --no-sudo
+rm -rf get_helm.sh
+

--- a/hello-world-read-module.yaml
+++ b/hello-world-read-module.yaml
@@ -16,15 +16,11 @@ spec:
   capabilities:
     - capability: read
       scope: workload
-      actions:
-        - name: RedactAction
-        - name: RemoveAction
       api:
-        endpoint:
-          port: 80
-          scheme: grpc
-        protocol: s3
-        dataformat: csv
+        connection:
+          name: rest
+          rest:
+            endpoint: "https://{{ .Release.Name }}.{{ .Release.Namespace }}:80/readAsset"
       supportedInterfaces:
         - source:
             protocol: s3
@@ -32,6 +28,9 @@ spec:
         - source:
             protocol: s3
             dataformat: csv
+      actions:
+        - name: RedactAction
+        - name: RemoveAction
   statusIndicators:
     - kind: hello-world-read-module
       successCondition: status.status == SUCCEEDED

--- a/hello-world-read-module.yaml
+++ b/hello-world-read-module.yaml
@@ -31,8 +31,3 @@ spec:
       actions:
         - name: RedactAction
         - name: RemoveAction
-  statusIndicators:
-    - kind: hello-world-read-module
-      successCondition: status.status == SUCCEEDED
-      failureCondition: status.status == FAILED
-      errorMessage: status.error

--- a/sample_assets/assetBank.yaml
+++ b/sample_assets/assetBank.yaml
@@ -5,19 +5,20 @@ metadata:
 spec:
   secretRef: 
     name: bank
-  assetDetails:
+  details:
     dataFormat: csv
     connection:
-      type: s3
+      name: s3
       s3:
         endpoint: "https://raw.githubusercontent.com/juliencohensolal/BankMarketing/master/rawData/bank-additional-full.csv"
         bucket: "bucket"
-        objectKey: "bank.csv"
-  assetMetadata:
+        object_key: "bank.csv"
+  metadata:
+    name: "Bank Asset"
     geography: theshire
     tags:
-    - finance
-    componentsMetadata:
-      age: 
+      finance: true
+    columns:
+      - name: age
         tags:
-        - PII
+          PII: true

--- a/sample_assets/assetMedals.yaml
+++ b/sample_assets/assetMedals.yaml
@@ -5,19 +5,20 @@ metadata:
 spec:
   secretRef: 
     name: medals-winners
-  assetDetails:
+  details:
     dataFormat: csv
     connection:
-      type: s3
+      name: s3
       s3:
         endpoint: "http://winterolympicsmedals.com/medals.csv"
         bucket: "bucket"
-        objectKey: "medals.csv"
-  assetMetadata:
+        object_key: "medals.csv"
+  metadata:
+    name: "Medals Winners"
     geography: theshire
     tags:
-    - finance
-    componentsMetadata:
-      age: 
+      finance: true
+    columns:
+      - name: age
         tags:
-        - sensitive
+          sensitive: true


### PR DESCRIPTION
This PR updates the module to work with Fybrik 0.6.0, it contains:
- use of Helm 3.7 to deploy the module helm chart in OCI registry
- update to Fybrik resources used in the example in the README 
- updates to the README file.
Closes #23 
Closes #30 