### PR TITLE
Updates to test_module.sh

### DIFF
--- a/.github/workflows/test-module.yaml
+++ b/.github/workflows/test-module.yaml
@@ -11,6 +11,10 @@ on:
       module-version:
         required: true
         default: '0.6.0'
+      cert-manager-version:
+        required: true
+        default: '1.6.2'
+
 
 env:
   GO_VERSION: 1.16
@@ -27,4 +31,4 @@ jobs:
     - name: Install tools
       run: make install-tools
     - name: run-test
-      run: pushd hack/tools && ls && ./test_module.sh ${{ github.event.inputs.kind-version }} ${{ github.event.inputs.fybrik-version }} ${{ github.event.inputs.module-version }} && popd
+      run: pushd hack/tools && ls && ./test_module.sh ${{ github.event.inputs.kind-version }} ${{ github.event.inputs.fybrik-version }} ${{ github.event.inputs.module-version }} ${{ github.event.inputs.cert-manager-version }} && popd


### PR DESCRIPTION
This PR updates test_module.sh scripts as follows:

 1)   it received cert-manager version as a parameter
 2)  it adds support for k8s version 20
 3)  it constructs the path to the local module resource from the module version which would be useful for testing patched versions like 0.6.1
