### PR TITLE
Updates to test_module.sh

### DIFF
--- a/.github/workflows/test-module.yaml
+++ b/.github/workflows/test-module.yaml
@@ -17,7 +17,7 @@ on:
 
 
 env:
-  GO_VERSION: 1.16
+  GO_VERSION: 1.17
 
 jobs:
   test-module:
@@ -31,4 +31,4 @@ jobs:
     - name: Install tools
       run: make install-tools
     - name: run-test
-      run: pushd hack/tools && ls && ./test_module.sh ${{ github.event.inputs.kind-version }} ${{ github.event.inputs.fybrik-version }} ${{ github.event.inputs.module-version }} ${{ github.event.inputs.cert-manager-version }} && popd
+      run: pushd hack/tools && ./test_module.sh ${{ github.event.inputs.kind-version }} ${{ github.event.inputs.fybrik-version }} ${{ github.event.inputs.module-version }} ${{ github.event.inputs.cert-manager-version }} && popd

--- a/hack/tools/test_module.sh
+++ b/hack/tools/test_module.sh
@@ -72,9 +72,21 @@ bin/helm install fybrik fybrik-charts/fybrik -n fybrik-system --version v$fybrik
 
 bin/kubectl wait --for=condition=ready --all pod -n fybrik-system --timeout=220s
 
-sleep 10
+# Related to https://github.com/cert-manager/cert-manager/issues/2908
+# Fybrik webhook not really ready after "helm install --wait"
+# A workaround is to loop until the module is applied as expected
+CMD="bin/kubectl apply -f https://github.com/fybrik/hello-world-read-module/releases/download/v$moduleVersion/hello-world-read-module.yaml -n fybrik-system"
+count=0
+until $CMD
+do
+  if [[ $count -eq 10 ]]
+  then
+    break
+  fi
+  sleep 1
+  ((count=count+1))
+done
 
-bin/kubectl apply -f https://github.com/fybrik/hello-world-read-module/releases/download/v$moduleVersion/hello-world-read-module.yaml -n fybrik-system
 
 # Notebook sample
 

--- a/hack/tools/test_module.sh
+++ b/hack/tools/test_module.sh
@@ -46,99 +46,72 @@ fi
 
 #quick start
 
-helm repo add jetstack https://charts.jetstack.io
-helm repo add hashicorp https://helm.releases.hashicorp.com
-helm repo add fybrik-charts https://fybrik.github.io/charts
-helm repo update
+bin/helm repo add jetstack https://charts.jetstack.io
+bin/helm repo add hashicorp https://helm.releases.hashicorp.com
+bin/helm repo add fybrik-charts https://fybrik.github.io/charts
+bin/helm repo update
 
 # https://cert-manager.io/docs/installation/supported-releases/
-helm install cert-manager jetstack/cert-manager \
+bin/helm install cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --version v$certManagerVersion \
     --create-namespace \
     --set installCRDs=true \
     --wait --timeout 220s
 
-# if [ $fybrikVersion == "dev" ]
-# then
-#     cd ${PATH_TO_LOCAL_FYBRIK}
-#     bin/helm dependency update charts/vault
-#     bin/helm install vault charts/vault --create-namespace -n fybrik-system \
-#         --set "vault.injector.enabled=false" \
-#         --set "vault.server.dev.enabled=true" \
-#         --values charts/vault/env/dev/vault-single-cluster-values.yaml
-#     kubectl wait --for=condition=ready --all pod -n fybrik-system --timeout=120s
 
-# else
-    bin/helm install vault fybrik-charts/vault --create-namespace -n fybrik-system \
-        --set "vault.injector.enabled=false" \
-        --set "vault.server.dev.enabled=true" \
-        --values https://raw.githubusercontent.com/fybrik/fybrik/v0.5.3/charts/vault/env/dev/vault-single-cluster-values.yaml
-    kubectl wait --for=condition=ready --all pod -n fybrik-system --timeout=220s
-# fi
-
-
+bin/helm install vault fybrik-charts/vault --create-namespace -n fybrik-system \
+    --set "vault.injector.enabled=false" \
+    --set "vault.server.dev.enabled=true" \
+   --values https://raw.githubusercontent.com/fybrik/fybrik/v0.5.3/charts/vault/env/dev/vault-single-cluster-values.yaml
+bin/kubectl wait --for=condition=ready --all pod -n fybrik-system --timeout=220s
 
 
 bin/helm install fybrik-crd fybrik-charts/fybrik-crd -n fybrik-system --version v$fybrikVersion --wait
 bin/helm install fybrik fybrik-charts/fybrik -n fybrik-system --version v$fybrikVersion --wait
 
-kubectl wait --for=condition=ready --all pod -n fybrik-system --timeout=220s
+bin/kubectl wait --for=condition=ready --all pod -n fybrik-system --timeout=220s
 
 sleep 10
 
-kubectl apply -f https://github.com/fybrik/hello-world-read-module/releases/download/v$moduleVersion/hello-world-read-module.yaml -n fybrik-system
-
-# cd ${PATH_TO_LOCAL_FYBRIK}
-# bin/helm install fybrik-crd charts/fybrik-crd -n fybrik-system --wait
-# bin/helm install fybrik charts/fybrik --set global.tag=master --set global.imagePullPolicy=Always -n fybrik-system --wait
-
-
-# hello-world-read-module
-# kubectl apply -f hello-world-read-module/hello-world-read-module.yaml -n fybrik-system
-# kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/main/hello-world-read-module.yaml -n fybrik-system
-
+bin/kubectl apply -f https://github.com/fybrik/hello-world-read-module/releases/download/v$moduleVersion/hello-world-read-module.yaml -n fybrik-system
 
 # Notebook sample
 
-kubectl create namespace fybrik-notebook-sample
-kubectl config set-context --current --namespace=fybrik-notebook-sample
+bin/kubectl create namespace fybrik-notebook-sample
+bin/kubectl config set-context --current --namespace=fybrik-notebook-sample
 
-kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/sample_assets/assetMedals.yaml -n fybrik-notebook-sample
-kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/sample_assets/secretMedals.yaml -n fybrik-notebook-sample
-kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/sample_assets/assetBank.yaml -n fybrik-notebook-sample
-kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/sample_assets/secretBank.yaml -n fybrik-notebook-sample
+bin/kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/sample_assets/assetMedals.yaml -n fybrik-notebook-sample
+bin/kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/sample_assets/secretMedals.yaml -n fybrik-notebook-sample
+bin/kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/sample_assets/assetBank.yaml -n fybrik-notebook-sample
+bin/kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/sample_assets/secretBank.yaml -n fybrik-notebook-sample
 
 
-kubectl -n fybrik-system create configmap sample-policy --from-file=$WORKING_DIR/sample-policy-$moduleResourceVersion.rego
-kubectl -n fybrik-system label configmap sample-policy openpolicyagent.org/policy=rego
-# while [[ $(kubectl get cm sample-policy -n fybrik-system -o 'jsonpath={.metadata.annotations.openpolicyagent\.org/policy-status}') != '{"status":"ok"}' ]]; sleep 5; done --timeout=120s
+bin/kubectl -n fybrik-system create configmap sample-policy --from-file=$WORKING_DIR/sample-policy-$moduleResourceVersion.rego
+bin/kubectl -n fybrik-system label configmap sample-policy openpolicyagent.org/policy=rego
 c=0
-while [[ $(kubectl get cm sample-policy -n fybrik-system -o 'jsonpath={.metadata.annotations.openpolicyagent\.org/policy-status}') != '{"status":"ok"}' ]]
+while [[ $(bin/kubectl get cm sample-policy -n fybrik-system -o 'jsonpath={.metadata.annotations.openpolicyagent\.org/policy-status}') != '{"status":"ok"}' ]]
 do
     echo "waiting"
     ((c++)) && ((c==25)) && break
     sleep 5
 done
 
-# timeout 5 bash -c -- 'while true; do printf ".";done'
-
-
-kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/fybrikapplication.yaml -n default
+bin/kubectl apply -f https://raw.githubusercontent.com/fybrik/hello-world-read-module/releases/$moduleVersion/fybrikapplication.yaml -n default
 
 c=0
-while [[ $(kubectl get fybrikapplication my-notebook -n default -o 'jsonpath={.status.ready}') != "true" ]]
+while [[ $(bin/kubectl get fybrikapplication my-notebook -n default -o 'jsonpath={.status.ready}') != "true" ]]
 do
     echo "waiting"
     ((c++)) && ((c==30)) && break
     sleep 6
 done
 
-kubectl get pods -n fybrik-blueprints
+bin/kubectl get pods -n fybrik-blueprints
 
-POD_NAME=$(kubectl get pods -n fybrik-blueprints -o=name | sed "s/^.\{4\}//")
+POD_NAME=$(bin/kubectl get pods -n fybrik-blueprints -o=name | sed "s/^.\{4\}//")
 
-kubectl logs ${POD_NAME} -n fybrik-blueprints > res.out
+bin/kubectl logs ${POD_NAME} -n fybrik-blueprints > res.out
 
 DIFF=$(diff $WORKING_DIR/expected-$moduleResourceVersion.txt res.out)
 if [ "${DIFF}" == "" ]
@@ -147,4 +120,3 @@ then
 else
     echo "test failed"
 fi
-# diff $WORKING_DIR/expected.txt res.out

--- a/hack/tools/test_module.sh
+++ b/hack/tools/test_module.sh
@@ -126,9 +126,19 @@ POD_NAME=$(bin/kubectl get pods -n fybrik-blueprints -o=name | sed "s/^.\{4\}//"
 bin/kubectl logs ${POD_NAME} -n fybrik-blueprints > res.out
 
 DIFF=$(diff $WORKING_DIR/expected-$moduleResourceVersion.txt res.out)
+RES=0
 if [ "${DIFF}" == "" ]
 then
     echo "test succeeded"
 else
-    echo "test failed"
+    RES=1
+fi
+
+bin/kubectl delete namespace fybrik-notebook-sample
+bin/kubectl -n fybrik-system delete configmap sample-policy
+
+if [ ${RES} == 1 ]
+then
+  echo "test failed"
+  exit 1
 fi


### PR DESCRIPTION
This PR contains the following changes:
* Set go version to 1.17
* Add missing bin/ prefix to helm and kubectl commands
* Avoid using sleep after fybrik deployment in test_module.sh (#44)
* Exit with error when the test fails.
Closes #44